### PR TITLE
Enable callback usage in PrettyPrint.

### DIFF
--- a/static/js/jclass.js
+++ b/static/js/jclass.js
@@ -672,7 +672,12 @@ N.html = function()
                 if (typeof initGist == 'function')
                     initGist();
                 if (typeof window.PR.prettyPrint == 'function')
-                    window.PR.prettyPrint();
+                    window.PR.prettyPrint (
+                        (typeof N.getStaticData().prettyPrintCallbackName !== 'undefined' &&
+                        typeof window[N.getStaticData().prettyPrintCallbackName] === 'function')
+                            ? window[N.getStaticData().prettyPrintCallbackName]
+                            : undefined
+                    );
             });
     };
 


### PR DESCRIPTION
This enables the possibility to use callbacks with PrettyPrint.

It is fairly easy: place in your template.values file, in whatever section you need to use the callback, a variable named `prettyPrintCallbackName`, and assign an UNIQUE name you will be using for that callback.

Then, in the corresponding JS file of your template, do something like `window['your_callback_name'] = function() { console.log ('Yay!'); }`. Voila, you're done.

This was done to circumvent an issue with the current NERDZ architecture: there is not a way to alter how BBCodes are displayed. My intention was to edit the output of the `[code]` tag, but without altering the main codebase (a thing which I don't wanna do) this is impossible without using an "hack" like this.

This commit **does not** break anything - any template not specifying this variable will not be affected.
