### PR TITLE
Remove the colon from the nick changed notice

### DIFF
--- a/pages/preferences/account.html.json.php
+++ b/pages/preferences/account.html.json.php
@@ -209,7 +209,7 @@ if($control)
 if($usernamechanged)
 {
     $lastpid = $core->countMessages(USERS_NEWS) + 1;
-    $message = "{$obj->username} %%12now is34%%: [user]{$user['username']}[/user].";
+    $message = "{$obj->username} %%12now is34%% [user]{$user['username']}[/user].";
 
     if(db::NO_ERR != $core->query(array('INSERT INTO "posts" ("from","to","pid","message","notify", "time") VALUES ('.USERS_NEWS.','.USERS_NEWS.",{$lastpid}, :msg , FALSE, NOW())",array($message)),db::FETCH_ERR))
         die($core->jsonResponse('error',$core->lang('ERROR')));


### PR DESCRIPTION
Many users reported that the colon is not necessary, so I removed it.
