### PR TITLE
git clone --recursive no longer breaks on mcilloni's repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,4 +12,4 @@
         url = git://github.com/nerdzeu/nerdz-template-black.git
 [submodule "class/pushed-php-client"]
 	path = class/pushed-php-client
-	url = git@github.com:mcilloni/pushed-php-client.git
+	url = git://github.com/mcilloni/pushed-php-client.git


### PR DESCRIPTION
Yesterday, I tried to git clone --recursive the repo, but it failed while cloning the [mcilloni/pushed-php-client](https://github.com/mcilloni/pushed-php-client) submodule.
This patch seems to fix the problem.
