### PR TITLE
Major changes to the PM/notification counters

### DIFF
--- a/static/js/jclass.js
+++ b/static/js/jclass.js
@@ -94,7 +94,7 @@ function N() /* THE FATHER of God (class/object/function)*/
         }
         else
         {
-            m = (117 - $obj.height()) / 2;
+            var m = (117 - $obj.height()) / 2;
             if (m > 1)
                 $obj.css ("margin-top", m);
         }


### PR DESCRIPTION
Here's a list of changes:
- Some code has been refactored (no more 2 spaces sh**).
- New API method: `N.isLoggedIn()`, checks if the PM counter exists.
- The counters are now event-based. Each time a new notification or PM is detected, an event is fired.
- NERDZ is now using these events internally, but they are available for every theme/userscript developer.
- You can subscribe to these events with jQuery using the `$(document).on ('eventName.yourNamespace', function (event, counter, previousCounter) { })`.

Event names:
- `nerdz:notification`: fired each time a new notification is detected.
- `nerdz:pm`: fired each time a new PM is detected.
- `nerdz_internal:set_counter`: an internal event used to manually set the counter to a specified value.

**WARNING:** since NERDZ is using these events you cannot unsubscribe to them using simply `$(document).off ('eventName')`, otherwise NERDZ notifications would stop working. You must use jQuery namespaces, please read more at http://api.jquery.com/on/#event-names . NERDZ is using the reserved namespace `nerdz`. Usage of that namespace is _forbidden_.

The common users will not notice these changes, unless something goes wrong (it shouldn't). The PMs got the priority over the notifications (so you will always see `[pm_count] (notification_count)` instead of `(notification_count) [pm_count]`).
